### PR TITLE
FIX package.xml dependency of uuv_smac_utils

### DIFF
--- a/uuv_smac_utils/package.xml
+++ b/uuv_smac_utils/package.xml
@@ -12,6 +12,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>uuv_simulation_evaluation</build_depend>
+
   <run_depend>uuv_simulation_evaluation</run_depend>
   <run_depend>uuv_simulation_wrapper</run_depend>
   <run_depend>roslib</run_depend>


### PR DESCRIPTION
When I built this project, I got following error.
This error would be occur using "catkin build".
Anyway, uuv_smac_utils will depends on uuv_simulation_evaluation on building.
Would it be better to add this dependency description? 

~~~
$ catkin_mmake install -j 4
:
:
-- Could NOT find uuv_simulation_evaluation (missing: uuv_simulation_evaluation_DIR)
-- Could not find the required component 'uuv_simulation_evaluation'. The following CMake error indicates that you either need to install the package with the same name or change your environment so that it can be found.
CMake Error at /opt/ros/melodic/share/catkin/cmake/catkinConfig.cmake:83 (find_package):
  Could not find a package configuration file provided by
  "uuv_simulation_evaluation" with any of the following names:

    uuv_simulation_evaluationConfig.cmake
    uuv_simulation_evaluation-config.cmake

  Add the installation prefix of "uuv_simulation_evaluation" to
  CMAKE_PREFIX_PATH or set "uuv_simulation_evaluation_DIR" to a directory
  containing one of the above files.  If "uuv_simulation_evaluation" provides
  a separate development package or SDK, be sure it has been installed.
Call Stack (most recent call first):
  uuv_simulation_evaluation/uuv_smac_utils/CMakeLists.txt:4 (find_package)


-- Configuring incomplete, errors occurred!
See also "/home/redhawk/uuvsimulator_ws_2/build/CMakeFiles/CMakeOutput.log".
See also "/home/redhawk/uuvsimulator_ws_2/build/CMakeFiles/CMakeError.log".
Invoking "cmake" failed
$
~~~