### PR TITLE
Fix usage of old message type `uuv_sensor_plugins_ros_msgs` in concentration parser

### DIFF
--- a/uuv_simulation_evaluation/src/uuv_bag_evaluation/data_parsers/concentration_sensor_data.py
+++ b/uuv_simulation_evaluation/src/uuv_bag_evaluation/data_parsers/concentration_sensor_data.py
@@ -28,7 +28,7 @@ class ConcentrationSensorData(SimulationData):
 
         for x in bag.get_type_and_topic_info():
             for k in x:
-                if 'uuv_sensor_plugins_ros_msgs/ChemicalParticleConcentration' in x[k][0]:
+                if 'uuv_sensor_ros_plugins_msgs/ChemicalParticleConcentration' in x[k][0]:
                     self._topic_name = k
                     self._logger.info('Particle concentration topic found <%s>' % k)
                     break


### PR DESCRIPTION
As mentioned in the Changelog 0.6.2

    Change name of uuv_sensor_plugins_ros_msgs to uuv_sensor_ros_plugins_msgs

But here are still the old names so i replaced old message type uuv_sensor_plugins_ros_msgs with new uuv_sensor_ros_plugins_msgs